### PR TITLE
Fixing Swift 4.1 warnings by adding #if swift(>=4.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <p align="center">
     <a href="https://developer.apple.com/swift/" target="_blank">
-        <img src="https://img.shields.io/badge/Swift-4.0-orange.svg?style=flat" alt="Swift 4.0">
+        <img src="https://img.shields.io/badge/Swift-4.1-orange.svg?style=flat" alt="Swift 4.1">
     </a>
     <a href="https://developer.apple.com/swift/" target="_blank">
         <img src="https://img.shields.io/badge/Platforms-OS%20X%20%7C%20Linux%20-lightgray.svg?style=flat" alt="Platforms OS X | Linux">

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -23,7 +23,7 @@
 
 <p align="center">
     <a href="https://developer.apple.com/swift/" target="_blank">
-        <img src="https://img.shields.io/badge/Swift-4.0-orange.svg?style=flat" alt="Swift 4.0">
+        <img src="https://img.shields.io/badge/Swift-4.1-orange.svg?style=flat" alt="Swift 4.1">
     </a>
     <a href="https://developer.apple.com/swift/" target="_blank">
         <img src="https://img.shields.io/badge/Platforms-OS%20X%20%7C%20Linux%20-lightgray.svg?style=flat" alt="Platforms OS X | Linux">

--- a/Sources/PerfectCrypto/Extensions.swift
+++ b/Sources/PerfectCrypto/Extensions.swift
@@ -68,7 +68,11 @@ public extension File {
 		self.close()
 		try chain.flush()
 		let validLength = digest.length
+		#if swift(>=4.1)
+		let ret = UnsafeMutableRawBufferPointer.allocate(byteCount: validLength, alignment: 0)
+		#else
 		let ret = UnsafeMutableRawBufferPointer.allocate(count: validLength)
+		#endif
 		guard try filter.get(ret) == validLength else {
 			ret.deallocate()
 			return []
@@ -280,7 +284,11 @@ public extension UnsafeMutableRawBufferPointer {
 	///
 	/// - Postcondition: The memory is allocated and initialized to random bits.
 	static func allocateRandom(count size: Int) -> UnsafeMutableRawBufferPointer? {
+		#if swift(>=4.1)
+		let ret = UnsafeMutableRawBufferPointer.allocate(byteCount: size, alignment: 0)
+		#else
 		let ret = UnsafeMutableRawBufferPointer.allocate(count: size)
+		#endif
 		guard 1 == internal_RAND_bytes(into: ret) else {
 			ret.deallocate()
 			return nil
@@ -300,7 +308,11 @@ public extension UnsafeRawBufferPointer {
 	///
 	/// - Postcondition: The memory is allocated and initialized to random bits.
 	static func allocateRandom(count size: Int) -> UnsafeRawBufferPointer? {
+		#if swift(>=4.1)
+		let ret = UnsafeMutableRawBufferPointer.allocate(byteCount: size, alignment: 0)
+		#else
 		let ret = UnsafeMutableRawBufferPointer.allocate(count: size)
+		#endif
 		guard 1 == internal_RAND_bytes(into: ret) else {
 			ret.deallocate()
 			return nil
@@ -326,7 +338,11 @@ public extension UnsafeRawBufferPointer {
 			_ = try chain.write(bytes: self)
 			try chain.flush()
 			let validLength = digest.length
+			#if swift(>=4.1)
+			let ret = UnsafeMutableRawBufferPointer.allocate(byteCount: validLength, alignment: 0)
+			#else
 			let ret = UnsafeMutableRawBufferPointer.allocate(count: validLength)
+			#endif
 			guard try filter.get(ret) == validLength else {
 				ret.deallocate()
 				return nil

--- a/Sources/PerfectCrypto/JWT.swift
+++ b/Sources/PerfectCrypto/JWT.swift
@@ -63,7 +63,11 @@ public struct JWTVerifier {
 	/// If verification succeeds then the `.headers` and `.payload` properties can be safely accessed.
 	public init?(_ jwt: String) {
 		let split = jwt.utf8.split(separator: dot, omittingEmptySubsequences: false)
+		#if swift(>=4.1)
+		let decoded = split.compactMap { $0.map { $0 }.decode(jwtEncoding) }
+		#else
 		let decoded = split.flatMap { $0.map { $0 }.decode(jwtEncoding) }
+		#endif
 		guard decoded.count == 3 else {
 			return nil
 		}

--- a/Sources/PerfectCrypto/OpenSSLInternal.swift
+++ b/Sources/PerfectCrypto/OpenSSLInternal.swift
@@ -67,7 +67,11 @@ extension CryptoError {
 		let maxLen = 1024
 		let buf = UnsafeMutablePointer<Int8>.allocate(capacity: maxLen)
 		defer {
+			#if swift(>=4.1)
+			buf.deallocate()
+			#else
 			buf.deallocate(capacity: maxLen)
+			#endif
 		}
 		ERR_error_string_n(errorCode, buf, maxLen)
 		let msg = String(validatingUTF8: buf) ?? ""
@@ -113,8 +117,13 @@ extension Encoding {
 			guard let memory = chain.memory else {
 				return nil
 			}
+			#if swift(>=4.1)
+			let ret = UnsafeMutableRawBufferPointer.allocate(byteCount: length, alignment: 0)
+			ret.copyMemory(from: memory)
+			#else
 			let ret = UnsafeMutableRawBufferPointer.allocate(count: length)
 			ret.copyBytes(from: memory)
+			#endif
 			return ret
 		} catch {
 			return nil
@@ -124,7 +133,11 @@ extension Encoding {
 	private func fromBytesBase64(_ source: UnsafeRawBufferPointer) -> UnsafeMutableRawBufferPointer? {
 		let chain = Base64Filter().chain(MemoryIO(source))
 		do {
+			#if swift(>=4.1)
+			let ret = UnsafeMutableRawBufferPointer.allocate(byteCount: source.count, alignment: 0)
+			#else
 			let ret = UnsafeMutableRawBufferPointer.allocate(count: source.count)
+			#endif
 			let count = try chain.read(ret)
 			return UnsafeMutableRawBufferPointer(start: ret.baseAddress, count: count)
 		} catch {
@@ -148,7 +161,11 @@ extension Encoding {
 					break
 				}
 			}
+			#if swift(>=4.1)
+			let ret = UnsafeMutableRawBufferPointer.allocate(byteCount: length, alignment: 0)
+			#else
 			let ret = UnsafeMutableRawBufferPointer.allocate(count: length)
+			#endif
 			for i in 0..<length {
 				switch memory[i] {
 				case plus:
@@ -182,7 +199,11 @@ extension Encoding {
 		let newPtr = UnsafeRawBufferPointer(start: deurled, count: deurled.count)
 		let chain = Base64Filter().chain(MemoryIO(newPtr))
 		do {
+			#if swift(>=4.1)
+			let ret = UnsafeMutableRawBufferPointer.allocate(byteCount: deurled.count, alignment: 0)
+			#else
 			let ret = UnsafeMutableRawBufferPointer.allocate(count: deurled.count)
+			#endif
 			let count = try chain.read(ret)
 			return UnsafeMutableRawBufferPointer(start: ret.baseAddress, count: count)
 		} catch {
@@ -192,7 +213,11 @@ extension Encoding {
 	
 	private func toBytesHex(_ source: UnsafeRawBufferPointer) -> UnsafeMutableRawBufferPointer? {
 		let sourceCount = source.count
+		#if swift(>=4.1)
+		let ret = UnsafeMutableRawBufferPointer.allocate(byteCount: sourceCount * 2, alignment: 0)
+		#else
 		let ret = UnsafeMutableRawBufferPointer.allocate(count: sourceCount * 2)
+		#endif
 		var ri = 0
 		for i in 0..<sourceCount {
 			let byte = source[i]
@@ -212,7 +237,11 @@ extension Encoding {
 		guard sourceCount % 2 == 0 else {
 			return nil
 		}
+		#if swift(>=4.1)
+		let ret = UnsafeMutableRawBufferPointer.allocate(byteCount: sourceCount / 2, alignment: 0)
+		#else
 		let ret = UnsafeMutableRawBufferPointer.allocate(count: sourceCount / 2)
+		#endif
 		var ri = 0
 		for index in stride(from: source.startIndex, to: source.endIndex, by: 2) {
 			guard let c = UInt8(hexOne: source[index], hexTwo: source[index+1]) else {
@@ -313,7 +342,11 @@ extension Digest {
 		guard 1 == EVP_DigestSignFinal(ctx, nil, &mdLen) else {
 			return nil
 		}
+		#if swift(>=4.1)
+		let ret = UnsafeMutableRawBufferPointer.allocate(byteCount: mdLen, alignment: 0)
+		#else
 		let ret = UnsafeMutableRawBufferPointer.allocate(count: mdLen)
+		#endif
 		var finalLen = mdLen
 		guard 1 == EVP_DigestSignFinal(ctx, ret.baseAddress?.assumingMemoryBound(to: UInt8.self), &finalLen) else {
 			ret.deallocate()
@@ -536,7 +569,11 @@ extension Cipher {
 			return nil
 		}
 		let allocLength = encryptLength(sourceCount: data.count)
+		#if swift(>=4.1)
+		let dstPtr = UnsafeMutableRawBufferPointer.allocate(byteCount: allocLength, alignment: 0)
+		#else
 		let dstPtr = UnsafeMutableRawBufferPointer.allocate(count: allocLength)
+		#endif
 		var wroteLength = Int32(0)
 		guard 1 == EVP_EncryptUpdate(ctx,
 		                             dstPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
@@ -555,7 +592,11 @@ extension Cipher {
 		}
 		let iwroteLength = Int(wroteLength) + owroteLength
 		if iwroteLength < allocLength {
+			#if swift(>=4.1)
+			let newDstPtr = UnsafeMutableRawBufferPointer.allocate(byteCount: iwroteLength, alignment: 0)
+			#else
 			let newDstPtr = UnsafeMutableRawBufferPointer.allocate(count: iwroteLength)
+			#endif
 			memcpy(newDstPtr.baseAddress!, dstPtr.baseAddress!, iwroteLength)
 			dstPtr.deallocate()
 			return newDstPtr
@@ -578,7 +619,11 @@ extension Cipher {
 										return nil
 		}
 		let allocLength = decryptLength(sourceCount: data.count)
+		#if swift(>=4.1)
+		let dstPtr = UnsafeMutableRawBufferPointer.allocate(byteCount: allocLength, alignment: 0)
+		#else
 		let dstPtr = UnsafeMutableRawBufferPointer.allocate(count: allocLength)
+		#endif
 		var wroteLength = Int32(0)
 		guard 1 == EVP_DecryptUpdate(ctx,
 		                             dstPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
@@ -597,7 +642,11 @@ extension Cipher {
 		}
 		let iwroteLength = Int(wroteLength) + owroteLength
 		if iwroteLength < allocLength {
+			#if swift(>=4.1)
+			let newDstPtr = UnsafeMutableRawBufferPointer.allocate(byteCount: iwroteLength, alignment: 0)
+			#else
 			let newDstPtr = UnsafeMutableRawBufferPointer.allocate(count: iwroteLength)
+			#endif
 			memcpy(newDstPtr.baseAddress!, dstPtr.baseAddress!, iwroteLength)
 			dstPtr.deallocate()
 			return newDstPtr
@@ -633,7 +682,11 @@ extension Cipher {
 				let mem = outBio.memory else {
 			return nil
 		}
+		#if swift(>=4.1)
+		let ret = UnsafeMutableRawBufferPointer.allocate(byteCount: mem.count, alignment: 0)
+		#else
 		let ret = UnsafeMutableRawBufferPointer.allocate(count: mem.count)
+		#endif
 		guard let r = ret.baseAddress, let m = mem.baseAddress else {
 			ret.deallocate()
 			return nil
@@ -672,7 +725,11 @@ extension Cipher {
 		guard let mem = outBio.memory, !mem.isEmpty else {
 			return nil
 		}
+		#if swift(>=4.1)
+		let ret = UnsafeMutableRawBufferPointer.allocate(byteCount: mem.count, alignment: 0)
+		#else
 		let ret = UnsafeMutableRawBufferPointer.allocate(count: mem.count)
+		#endif
 		guard let r = ret.baseAddress, let m = mem.baseAddress else {
 			ret.deallocate()
 			return nil

--- a/Tests/PerfectCryptoTests/PerfectCryptoTests.swift
+++ b/Tests/PerfectCryptoTests/PerfectCryptoTests.swift
@@ -120,7 +120,11 @@ class PerfectCryptoTests: XCTestCase {
 			try write.pair(with: read)
 			_ = try write.write(bytes: ptr)
 			try write.flush()
+			#if swift(>=4.1)
+			let dest = UnsafeMutableRawBufferPointer.allocate(byteCount: 1024, alignment: 0)
+			#else
 			let dest = UnsafeMutableRawBufferPointer.allocate(count: 1024)
+			#endif
 			defer {
 				dest.deallocate()
 			}
@@ -139,7 +143,11 @@ class PerfectCryptoTests: XCTestCase {
 		let chain = Base64Filter().chain(MemoryIO())
 		do {
 			XCTAssert(try chain.write(bytes: ptr) == count)
+			#if swift(>=4.1)
+			let dest = UnsafeMutableRawBufferPointer.allocate(byteCount: 1024, alignment: 0)
+			#else
 			let dest = UnsafeMutableRawBufferPointer.allocate(count: 1024)
+			#endif
 			defer {
 				dest.deallocate()
 			}
@@ -175,7 +183,11 @@ class PerfectCryptoTests: XCTestCase {
 		let testStr = "Hello, world!"
 		let testAnswer = "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3"
 		
+		#if swift(>=4.1)
+		let dest = UnsafeMutableRawBufferPointer.allocate(byteCount: 1024, alignment: 0)
+		#else
 		let dest = UnsafeMutableRawBufferPointer.allocate(count: 1024)
+		#endif
 		defer {
 			dest.deallocate()
 		}
@@ -534,7 +546,11 @@ class PerfectCryptoTests: XCTestCase {
 			let _bufferSize = 16384
 			let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: _bufferSize)
 			defer {
+				#if swift(>=4.1)
+				buffer.deallocate()
+				#else
 				buffer.deallocate(capacity: _bufferSize)
+				#endif
 			}
 			var buf: [UInt8] = []
 			repeat {


### PR DESCRIPTION
Tested on mac/linux with:
- Swift 4.0.3
- Swift 4.1